### PR TITLE
Async implementation for the OkHttp driver

### DIFF
--- a/drivers/okhttp/src/main/java/org/jclouds/http/okhttp/OkHttpCommandExecutorService.java
+++ b/drivers/okhttp/src/main/java/org/jclouds/http/okhttp/OkHttpCommandExecutorService.java
@@ -48,32 +48,38 @@ import org.jclouds.io.MutableContentMetadata;
 import org.jclouds.io.Payload;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableMultimap.Builder;
 import com.google.inject.Inject;
+import com.squareup.okhttp.Callback;
 import com.squareup.okhttp.Headers;
 import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.Response;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 
 public final class OkHttpCommandExecutorService extends BaseHttpCommandExecutorService<Request> {
    private final Function<URI, Proxy> proxyForURI;
    private final OkHttpClient globalClient;
    private final String userAgent;
+   private final Function<Response, HttpResponse> responseTransformer;
 
    @Inject
    OkHttpCommandExecutorService(HttpUtils utils, ContentMetadataCodec contentMetadataCodec,
          DelegatingRetryHandler retryHandler, IOExceptionRetryHandler ioRetryHandler,
          DelegatingErrorHandler errorHandler, HttpWire wire, Function<URI, Proxy> proxyForURI, OkHttpClient okHttpClient,
          @Named(PROPERTY_IDEMPOTENT_METHODS) String idempotentMethods,
-         @Named(PROPERTY_USER_AGENT) String userAgent) {
+         @Named(PROPERTY_USER_AGENT) String userAgent, Function<Response, HttpResponse> responseTransformer) {
       super(utils, contentMetadataCodec, retryHandler, ioRetryHandler, errorHandler, wire, idempotentMethods);
       this.proxyForURI = proxyForURI;
       this.globalClient = okHttpClient;
       this.userAgent = userAgent;
+      this.responseTransformer = responseTransformer;
    }
 
    @Override
@@ -152,39 +158,77 @@ public final class OkHttpCommandExecutorService extends BaseHttpCommandExecutorS
       requestScopedClient.setProxy(proxyForURI.apply(nativeRequest.uri()));
 
       Response response = requestScopedClient.newCall(nativeRequest).execute();
-
-      HttpResponse.Builder<?> builder = HttpResponse.builder();
-      builder.statusCode(response.code());
-      builder.message(response.message());
-
-      Builder<String, String> headerBuilder = ImmutableMultimap.builder();
-      Headers responseHeaders = response.headers();
-      for (String header : responseHeaders.names()) {
-         headerBuilder.putAll(header, responseHeaders.values(header));
-      }
-
-      ImmutableMultimap<String, String> headers = headerBuilder.build();
-
-      if (response.code() == 204 && response.body() != null) {
-         response.body().close();
-      } else {
-         Payload payload = newInputStreamPayload(response.body().byteStream());
-         contentMetadataCodec.fromHeaders(payload.getContentMetadata(), headers);
-         builder.payload(payload);
-      }
-
-      builder.headers(filterOutContentHeaders(headers));
-
-      return builder.build();
+      return responseTransformer.apply(response);
    }
 
    @Override
    protected ListenableFuture<HttpResponse> invokeAsync(final Request nativeRequest) {
-      throw new UnsupportedOperationException("unsupported operation");
+      OkHttpClient requestScopedClient = globalClient.clone();
+      try {
+         requestScopedClient.setProxy(proxyForURI.apply(nativeRequest.uri()));
+      } catch (IOException ex) {
+         throw Throwables.propagate(ex);
+      }
+
+      SettableFuture<Response> responseFuture = SettableFuture.create();
+      requestScopedClient.newCall(nativeRequest).enqueue(new Callback() {
+         @Override
+         public void onResponse(Response response) throws IOException {
+            responseFuture.set(response);
+         }
+
+         @Override
+         public void onFailure(Request request, IOException ex) {
+            responseFuture.setException(ex);
+         }
+      });
+
+      return Futures.transform(responseFuture, responseTransformer);
    }
 
    @Override
    protected void cleanup(Request nativeResponse) {
+
+   }
+   
+   public static class ResponseTransformer implements Function<Response, HttpResponse> {
+      protected final ContentMetadataCodec contentMetadataCodec;
+
+      @Inject
+      ResponseTransformer(ContentMetadataCodec contentMetadataCodec) {
+         this.contentMetadataCodec = contentMetadataCodec;
+      }
+
+      @Override
+      public HttpResponse apply(Response response) {
+         HttpResponse.Builder<?> builder = HttpResponse.builder();
+         builder.statusCode(response.code());
+         builder.message(response.message());
+
+         Builder<String, String> headerBuilder = ImmutableMultimap.builder();
+         Headers responseHeaders = response.headers();
+         for (String header : responseHeaders.names()) {
+            headerBuilder.putAll(header, responseHeaders.values(header));
+         }
+
+         ImmutableMultimap<String, String> headers = headerBuilder.build();
+
+         if (response.code() == 204 && response.body() != null) {
+            try {
+               response.body().close();
+            } catch (IOException ex) {
+               throw Throwables.propagate(ex);
+            }
+         } else {
+            Payload payload = newInputStreamPayload(response.body().byteStream());
+            contentMetadataCodec.fromHeaders(payload.getContentMetadata(), headers);
+            builder.payload(payload);
+         }
+
+         builder.headers(filterOutContentHeaders(headers));
+
+         return builder.build();
+      }
 
    }
 

--- a/drivers/okhttp/src/main/java/org/jclouds/http/okhttp/config/OkHttpCommandExecutorServiceModule.java
+++ b/drivers/okhttp/src/main/java/org/jclouds/http/okhttp/config/OkHttpCommandExecutorServiceModule.java
@@ -23,18 +23,23 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 
 import org.jclouds.http.HttpCommandExecutorService;
+import org.jclouds.http.HttpResponse;
 import org.jclouds.http.HttpUtils;
 import org.jclouds.http.config.ConfiguresHttpCommandExecutorService;
 import org.jclouds.http.config.SSLModule;
 import org.jclouds.http.okhttp.OkHttpClientSupplier;
 import org.jclouds.http.okhttp.OkHttpCommandExecutorService;
+import org.jclouds.http.okhttp.OkHttpCommandExecutorService.ResponseTransformer;
 
+import com.google.common.base.Function;
 import com.google.common.base.Supplier;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Scopes;
+import com.google.inject.TypeLiteral;
 import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Response;
 
 /**
  * Configures the {@link OkHttpCommandExecutorService}.
@@ -49,6 +54,8 @@ public class OkHttpCommandExecutorServiceModule extends AbstractModule {
       install(new SSLModule());
       bind(HttpCommandExecutorService.class).to(OkHttpCommandExecutorService.class).in(Scopes.SINGLETON);
       bind(OkHttpClient.class).toProvider(OkHttpClientProvider.class).in(Scopes.SINGLETON);
+      bind(new TypeLiteral<Function<Response, HttpResponse>>() {
+      }).to(ResponseTransformer.class).in(Scopes.SINGLETON);
    }
 
    private static final class OkHttpClientProvider implements Provider<OkHttpClient> {


### PR DESCRIPTION
Just looking at your branch and following the same principles than the Apache HTTP driver, I've implemented the `invokeAsync` for the OkHttp driver, since it also provides a way to perform async requests. Quite trivial! This would allow us to early test the feature with this driver, which is used by default by several providers (Docker, Azure ARM, and others).

I have not tried this, so feel free to add it to your branch or to ignore it completely :)